### PR TITLE
Create actual Order before prompting the Customer to make Payment

### DIFF
--- a/Observer/AfterOrderObserver.php
+++ b/Observer/AfterOrderObserver.php
@@ -5,6 +5,7 @@ namespace Profibro\Paystack\Observer;
 
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Sales\Model\Order;
+use Profibro\Paystack\Model\Payment;
 
 class AfterOrderObserver implements ObserverInterface
 {
@@ -18,7 +19,13 @@ class AfterOrderObserver implements ObserverInterface
     {
         //Observer execution code...
         $order = $observer->getEvent()->getOrder();
-        $order->setStatus(Order::STATE_PROCESSING);
-        $order->save();
+        // get the payment method instance
+        $method = $order->getPayment()->getMethodInstance();
+        // if order payment method is paystack
+        if ($method->getCode() === Payment::CODE) {
+            // set the order status to 'pending_payment'
+            $order->setStatus(Order::STATE_PENDING_PAYMENT);
+            $order->save();
+        }
     }
 }

--- a/Observer/AfterOrderObserver.php
+++ b/Observer/AfterOrderObserver.php
@@ -16,7 +16,7 @@ class AfterOrderObserver implements ObserverInterface
 
     public function execute(\Magento\Framework\Event\Observer $observer)
     {
-    //Observer execution code...
+        //Observer execution code...
         $order = $observer->getEvent()->getOrder();
         $order->setStatus(Order::STATE_PROCESSING);
         $order->save();

--- a/Observer/AfterPaymentVerifyObserver.php
+++ b/Observer/AfterPaymentVerifyObserver.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Profibro\Paystack\Observer;
+
+
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Sales\Model\Order;
+
+class AfterPaymentVerifyObserver implements ObserverInterface
+{
+    /**
+     * @var \Magento\Sales\Model\OrderFactory $_orderFactory
+     */
+    protected $_orderFactory;
+    
+    /**
+     * @var \Magento\Checkout\Model\Session $_checkoutSession
+     */
+    protected $_checkoutSession;
+    
+    public function __construct(
+        \Magento\Sales\Model\OrderFactory $orderFactory,
+        \Magento\Checkout\Model\Session $checkoutSession
+    ) {
+        $this->_checkoutSession = $checkoutSession;
+        $this->_orderFactory = $orderFactory;
+    }
+
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        //Observer execution code...
+        $order = $this->getOrder();
+        if ($order) {
+            // sets the status to processing since payment has been received
+            $order->setStatus(Order::STATE_PROCESSING);
+            $order->save();
+        }
+    }
+    
+    /**
+     * Loads the order based on the last real order
+     * @return boolean | 
+     */
+    private function getOrder()
+    {
+        // get the last real order id
+        $lastOrderId = $this->_checkoutSession->getLastRealOrderId();
+        if ($lastOrderId) {
+            // load and return the order instance
+            return $this->_orderFactory->create()->loadByIncrementId($lastOrderId);
+        }
+        return false;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ php bin/magento setup:upgrade
 php bin/magento setup:di:compile
 ```
 
-None Errors
-===========
+Known Errors
+============
 
 * Fail to redirect to success page after successful payment
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,10 @@ None Errors
 * Fail to redirect to success page after successful payment
 
 Sometimes after receiving payment for an order you get an error like: `Class Yabacon\Paystack not found` 
-and magento doesn't redirect to the `success` page
+and magento doesn't redirect to the `success` page.
 
-Fix
-===
-
-* Run the following command:
+** Fix:
+Run the following command:
 
 ```bash
 composer require yabacon/paystack-php

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ php bin/magento setup:upgrade
 php bin/magento setup:di:compile
 ```
 
+None Errors
+===========
+
+Sometimes after receiving payment for an order you get an error like: `Class Yabacon\Paystack not found` 
+and magento doesn't redirect to the `success` page
+
+Fix
+===
+
+* Run the following command:
+
+```bash
+composer require yabacon/paystack-php
+```
+
+
+
 * Enable and configure `Paystack` in *Magento Admin* under `Stores/Configuration/Payment` Methods
 
 [ico-version]: https://img.shields.io/packagist/v/profibro/magento2-module-paystack.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ php bin/magento setup:di:compile
 None Errors
 ===========
 
+* Fail to redirect to success page after successful payment
+
 Sometimes after receiving payment for an order you get an error like: `Class Yabacon\Paystack not found` 
 and magento doesn't redirect to the `success` page
 

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -3,4 +3,7 @@
     <event name="sales_order_place_after">
         <observer name="AfterOrderObserver" instance="Profibro\Paystack\Observer\AfterOrderObserver" />
     </event>
+    <event name="payment_verify_after">
+        <observer name="AfterPaymentVerifyObserver" instance="Profibro\Paystack\Observer\AfterPaymentVerifyObserver" />
+    </event>
 </config>

--- a/view/frontend/web/js/view/payment/method-renderer/profibro_paystack.js
+++ b/view/frontend/web/js/view/payment/method-renderer/profibro_paystack.js
@@ -19,7 +19,7 @@ define(
                 customObserverName: null
             },
             
-            redirectAfterPlaceOrder : true,
+            redirectAfterPlaceOrder : false,
 
             initialize: function () {
                 this._super();
@@ -46,7 +46,7 @@ define(
             /**
              * @override
              */
-            placeOrder: function () {
+            afterPlaceOrder: function () {
                 var checkoutConfig = window.checkoutConfig;
                 var paymentData = quote.billingAddress();
                 var profibroPaystackConfiguration = checkoutConfig.payment.profibro_paystack;
@@ -105,7 +105,8 @@ define(
                             
                             if (data.status) {
                                 if (data.data.status === 'success') {
-                                    _this.processPayment();
+                                    // redirect to success page after
+                                    redirectOnSuccessAction.execute();
                                     return;
                                 }
                             }
@@ -119,31 +120,6 @@ define(
                   }
                 });
                 handler.openIframe();
-            },
-
-            processPayment: function () {
-                var self = this,
-                    placeOrder;
-
-                if (this.validate() && additionalValidators.validate()) {
-                    this.isPlaceOrderActionAllowed(false);
-                    placeOrder = placeOrderAction(this.getData(), this.messageContainer);
-                    $.when(placeOrder).fail(function () {
-                        self.isPlaceOrderActionAllowed(true);
-                    }).done(
-                        function () {
-                            self.afterPlaceOrder();
-
-                            if (self.redirectAfterPlaceOrder) {
-                                redirectOnSuccessAction.execute();
-                            }
-                        }
-                    );
-
-                    return true;
-                }
-
-                return false;
             }
         });
     }


### PR DESCRIPTION
Lets the system create the Order on clicking 'place order' button and only prompting to make payment on order success as proposed in issue #11 

Other Changes made
================

In the `view/frontend/web/js/view/payment/method-renderer/profibro_paystack.js`:
1. Set the `redirectAfterPlaceOrder`  to `false` so the system doesn't redirect automatically to the success page.
2. Hook into the `afterPlaceOrder` method as opposed to the `placeOrder` method.
Calls the `redirectOnSuccessAction.execute();` after payment verification runs successfully.