### PR TITLE
 Fix Issue #36: Invalid Email Error On Magento 2.3.1

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/pstk_paystack.js
+++ b/view/frontend/web/js/view/payment/method-renderer/pstk_paystack.js
@@ -63,9 +63,6 @@ define(
           var customerData = checkoutConfig.customerData;
           paymentData.email = customerData.email;
         } else {
-          var storageData = JSON.parse(
-            localStorage.getItem("mage-cache-storage")
-          )["checkout-data"];
           paymentData.email = quote.guestEmail;
         }
 

--- a/view/frontend/web/js/view/payment/method-renderer/pstk_paystack.js
+++ b/view/frontend/web/js/view/payment/method-renderer/pstk_paystack.js
@@ -66,7 +66,7 @@ define(
           var storageData = JSON.parse(
             localStorage.getItem("mage-cache-storage")
           )["checkout-data"];
-          paymentData.email = storageData.validatedEmailValue;
+          paymentData.email = quote.guestEmail;
         }
 
         var quoteId = checkoutConfig.quoteItemData[0].quote_id;


### PR DESCRIPTION
Customer email is not available in billing address data when checking out as a guest, but guestEmail is available in the injected quote data on checkout.