### PR TITLE
Fix/adobe commerce php84 nullable

### DIFF
--- a/Model/Payment/Paystack.php
+++ b/Model/Payment/Paystack.php
@@ -35,7 +35,7 @@ class Paystack extends \Magento\Payment\Model\Method\AbstractMethod
     protected $_isOffline = true;
 
     public function isAvailable(
-        \Magento\Quote\Api\Data\CartInterface $quote = null
+        ?\Magento\Quote\Api\Data\CartInterface $quote = null
     ) {
         return parent::isAvailable($quote);
     }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "pstk/paystack-magento2-module",
     "description": "Paystack Magento2 Module using \\Magento\\Payment\\Model\\Method\\AbstractMethod",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "require": {},
     "type": "magento2-module",
     "license": [


### PR DESCRIPTION
PHP 8.4 compatibility for Adobe Commerce (explicit nullable in Paystack::isAvailable). Bumps version to 3.0.1.