### PR TITLE
Send the transaction amount to Paystack as an integer number of kobo

### DIFF
--- a/Controller/Payment/Setup.php
+++ b/Controller/Payment/Setup.php
@@ -51,7 +51,7 @@ class Setup extends AbstractPaystackStandard {
         $tranx = $this->paystackClient->initializeTransaction([
             'first_name' => $order->getCustomerFirstname(),
             'last_name' => $order->getCustomerLastname(),
-            'amount' => $order->getGrandTotal() * 100, // in kobo
+            'amount' => (int) round($order->getGrandTotal() * 100), // in kobo (integer, subunit)
             'email' => $order->getCustomerEmail(), // unique to customers
             'reference' => $order->getIncrementId(), // unique to transactions
             'currency' => $order->getCurrency(),


### PR DESCRIPTION
The amount was calculated as $order->getGrandTotal() * 100. Grand totals are floating point, so multiplying by 100 introduces the usual float representation error and the value is then JSON encoded and sent to Paystack as a fractional number.

For example a 19.99 order total becomes 1998.9999999999998 instead of 1999, and is sent as {"amount":1998.9999999999998}. Paystack expects the amount in the currency subunit (kobo) as an integer, so a fractional amount is either rejected or truncated, which undercharges the customer. Other common totals hit this too: 1.10 -> 110.00000000000001, 0.29 -> 28.999999999999996, 8.21 -> 821.0000000000001.

Wrapping the calculation in (int) round(...) sends a correct integer amount for every total.